### PR TITLE
fix socket.error raises

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -52,6 +52,16 @@ NONBLOCKING_EXCEPTION_ERROR_NUMBERS = {
     ssl.SSLError: 2,
 }
 
+# In Python 2.7 a socket.error is raised for a nonblocking read.
+# The _compat module aliases BlockingIOError to socket.error to be
+# Python 2/3 compatible.
+# However this means that all socket.error exceptions need to be handled
+# properly within these exception handlers.
+# We need to make sure socket.error is included in these handlers and
+# provide a dummy error number that will never match a real exception.
+if socket.error not in NONBLOCKING_EXCEPTION_ERROR_NUMBERS:
+    NONBLOCKING_EXCEPTION_ERROR_NUMBERS[socket.error] = -999999
+
 NONBLOCKING_EXCEPTIONS = tuple(NONBLOCKING_EXCEPTION_ERROR_NUMBERS.keys())
 
 try:


### PR DESCRIPTION
Fixes #1121

<!-- Thank you for your contribution! -->

## What do these changes do?

fix raise `aioredis.exceptions.ConnectionError` instead of raw `socket.error` or its subclasses

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

no

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#1121
<!-- Are there any issues opened that will be resolved by merging this change? -->